### PR TITLE
systemd: restart minio if it was accidentally, but gracefully stopped.

### DIFF
--- a/linux-systemd/minio.service
+++ b/linux-systemd/minio.service
@@ -18,6 +18,9 @@ ExecStartPre=/bin/bash -c "[ -n \"${MINIO_VOLUMES}\" ] || echo \"Variable MINIO_
 
 ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
 
+# Let systemd restart this service only if it has ended with the clean exit code or signal.
+Restart=on-success
+
 StandardOutput=journal
 StandardError=inherit
 


### PR DESCRIPTION
This returns a standard systemd service behavior. In particular, this allows
Minio to get automatically restarted by the systemd either when
``mc admin service restart TARGET`` or ``kill <pid_of_minio>`` command was used,
i.e. when the service has been gracefully attempted to be restarted or
accidentally stopped.