### PR TITLE
Change minio.service environment variable test logic

### DIFF
--- a/linux-systemd/minio.service
+++ b/linux-systemd/minio.service
@@ -14,7 +14,7 @@ Group=minio-user
 PermissionsStartOnly=true
 
 EnvironmentFile=-/etc/default/minio
-ExecStartPre=/bin/bash -c "[ -n \"${MINIO_VOLUMES}\" ] && echo \"Variable MINIO_VOLUMES not set in /etc/default/minio\""
+ExecStartPre=/bin/bash -c "[ -z \"${MINIO_VOLUMES}\" ] && echo \"Variable MINIO_VOLUMES not set in /etc/default/minio\""
 
 ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
 


### PR DESCRIPTION
The test generates a warning when the variable is set. The operator should be -z, not -n.