### PR TITLE
Change distributed minio.service environment variable test logic

### DIFF
--- a/linux-systemd/distributed/minio.service
+++ b/linux-systemd/distributed/minio.service
@@ -14,9 +14,9 @@ Group=minio-user
 PermissionsStartOnly=true
 
 EnvironmentFile=-/etc/default/minio
-ExecStartPre=/bin/bash -c "[ -n \"${MINIO_VOLUMES}\" ] && echo \"Variable MINIO_VOLUMES not set in /etc/default/minio\""
-ExecStartPre=/bin/bash -c "[ -n \"${MINIO_ACCESS_KEY}\" ] && echo \"Variable MINIO_ACCESS_KEY not set in /etc/default/minio\""
-ExecStartPre=/bin/bash -c "[ -n \"${MINIO_SECRET_KEY}\" ] && echo \"Variable MINIO_SECRET_KEY not set in /etc/default/minio\""
+ExecStartPre=/bin/bash -c "[ -z \"${MINIO_VOLUMES}\" ] && echo \"Variable MINIO_VOLUMES not set in /etc/default/minio\""
+ExecStartPre=/bin/bash -c "[ -z \"${MINIO_ACCESS_KEY}\" ] && echo \"Variable MINIO_ACCESS_KEY not set in /etc/default/minio\""
+ExecStartPre=/bin/bash -c "[ -z \"${MINIO_SECRET_KEY}\" ] && echo \"Variable MINIO_SECRET_KEY not set in /etc/default/minio\""
 
 ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
 


### PR DESCRIPTION
The test generates a warning when the variable is set. The operator should be -z, not -n.