### PR TITLE
check for /etc/default/minio is not empty

### DIFF
--- a/linux-systemd/minio.service
+++ b/linux-systemd/minio.service
@@ -4,6 +4,9 @@ Documentation=https://docs.min.io
 Wants=network-online.target
 After=network-online.target
 AssertFileIsExecutable=/usr/local/bin/minio
+AssertFileNotEmpty=/etc/default/minio
+# From Systemd 246/247 AssertEnvironment can be used instead of ExecStartPre Bash one-liner.
+#AssertEnvironment=MINIO_VOLUMES
 
 [Service]
 WorkingDirectory=/usr/local/

--- a/linux-systemd/minio.service
+++ b/linux-systemd/minio.service
@@ -5,8 +5,6 @@ Wants=network-online.target
 After=network-online.target
 AssertFileIsExecutable=/usr/local/bin/minio
 AssertFileNotEmpty=/etc/default/minio
-# From Systemd 246/247 AssertEnvironment can be used instead of ExecStartPre Bash one-liner.
-#AssertEnvironment=MINIO_VOLUMES
 
 [Service]
 WorkingDirectory=/usr/local/


### PR DESCRIPTION
Add assertion check is default environment file exist and not empty.
Add optional assertion check is MINIO_VOLUMES set (can be used from Systemd 246/247 instead of ExecStartPre Bash one-liner).