### PR TITLE
Use Type=notify

### DIFF
--- a/linux-systemd/distributed/minio.service
+++ b/linux-systemd/distributed/minio.service
@@ -6,6 +6,8 @@ After=network-online.target
 AssertFileIsExecutable=/usr/local/bin/minio
 
 [Service]
+Type=notify
+
 WorkingDirectory=/usr/local
 
 User=minio-user

--- a/linux-systemd/minio.service
+++ b/linux-systemd/minio.service
@@ -6,6 +6,8 @@ After=network-online.target
 AssertFileIsExecutable=/usr/local/bin/minio
 
 [Service]
+Type=notify
+
 WorkingDirectory=/usr/local/
 
 User=minio-user


### PR DESCRIPTION
This tells systemd that `minio` supports startup notification protocol, and will wait until it tells it's ready before launching dependent (`After=`) services.

See https://github.com/minio/minio/pull/17062

Note that unlike unlike the linked PR, this change is not backward compatible: attempting to run `Type=notify` service with old MinIO binary will result in startup timing out. This should not be merged until new MinIO version is released (partly because some of the documentation advises to download the unit file directly from master), and possibly it might be a good idea to delay it a bit further than that.