### PR TITLE
Adjust OOM score of MinIO to -1000 to prevent oomkill

### DIFF
--- a/linux-systemd/distributed/minio.service
+++ b/linux-systemd/distributed/minio.service
@@ -32,6 +32,9 @@ TasksMax=infinity
 # Disable timeout logic and wait until process is stopped
 TimeoutSec=infinity
 
+# Disable killing of MinIO by the kernel's OOM killer
+OOMScoreAdjust=-1000
+
 SendSIGKILL=no
 
 [Install]

--- a/linux-systemd/minio.service
+++ b/linux-systemd/minio.service
@@ -30,6 +30,9 @@ TasksMax=infinity
 # Disable timeout logic and wait until process is stopped
 TimeoutSec=infinity
 
+# Disable killing of MinIO by the kernel's OOM killer
+OOMScoreAdjust=-1000
+
 SendSIGKILL=no
 
 [Install]


### PR DESCRIPTION
Docs: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#OOMScoreAdjust=

The idea here is that the kernel can kill other user-space processes but leave MinIO. We find there are other causes of memory leaks and it's better to keep MinIO up as a critical service. The Go runtime will eventually panic if memory cannot be allocated. 