### PR TITLE
feat: add Linux capabilities for privileged ports and S.M.A.R.T. monitorning

### DIFF
--- a/linux-systemd/README.md
+++ b/linux-systemd/README.md
@@ -30,22 +30,46 @@ EOT
 
 ## Systemctl
 
-Download `minio.service` in  `/lib/systemd/system/`
+Download `minio.service` in `/lib/systemd/system/`
+
 ```
 ( cd /lib/systemd/system/; curl -O https://raw.githubusercontent.com/minio/minio-service/master/linux-systemd/minio.service )
 ```
 
 ### Enable startup on boot
+
 ```
 systemctl enable minio.service
 ```
 
 ### Disable MinIO service
+
 ```
 systemctl disable minio.service
+```
+
+## Linux Capabilities
+
+The service file includes the following ambient capabilities:
+
+| Capability             | Purpose                                                 |
+| ---------------------- | ------------------------------------------------------- |
+| `CAP_NET_BIND_SERVICE` | Bind to privileged ports (< 1024)                       |
+| `CAP_SYS_ADMIN`        | S.M.A.R.T. disk health monitoring (NVMe admin commands) |
+| `CAP_DAC_OVERRIDE`     | S.M.A.R.T. disk health monitoring (open block devices)  |
+
+If you're running MinIO outside of systemd, set the capabilities on the binary:
+
+```sh
+sudo setcap 'cap_net_bind_service,cap_sys_admin,cap_dac_override=+ep' /usr/local/bin/minio
+```
+
+For privileged port binding only:
+
+```sh
+sudo setcap cap_net_bind_service=+ep /usr/local/bin/minio
 ```
 
 ## NOTE
 
 Ensure `minio-user` is created on the host with write access to data folders.
-

--- a/linux-systemd/distributed/README.md
+++ b/linux-systemd/distributed/README.md
@@ -32,7 +32,7 @@ For distributed setup it is required to copy this file across all nodes to have 
 
 ## Systemctl
 
-Download `minio.service` in  `/lib/systemd/system/`
+Download `minio.service` in `/lib/systemd/system/`
 
 ```
 ( cd /lib/systemd/system/; curl -O https://raw.githubusercontent.com/minio/minio-service/master/linux-systemd/distributed/minio.service )
@@ -44,6 +44,28 @@ Enable startup on boot
 systemctl enable minio.service
 ```
 
+## Linux Capabilities
+
+The service file includes the following ambient capabilities:
+
+| Capability             | Purpose                                                 |
+| ---------------------- | ------------------------------------------------------- |
+| `CAP_NET_BIND_SERVICE` | Bind to privileged ports (< 1024)                       |
+| `CAP_SYS_ADMIN`        | S.M.A.R.T. disk health monitoring (NVMe admin commands) |
+| `CAP_DAC_OVERRIDE`     | S.M.A.R.T. disk health monitoring (open block devices)  |
+
+If you're running MinIO outside of systemd, set the capabilities on the binary:
+
+```sh
+sudo setcap 'cap_net_bind_service,cap_sys_admin,cap_dac_override=+ep' /usr/local/bin/minio
+```
+
+For privileged port binding only:
+
+```sh
+sudo setcap cap_net_bind_service=+ep /usr/local/bin/minio
+```
+
 ## NOTE
 
-Ensure `minio-user` is created on all thes hosts in distributed setup with write access to data folders.
+Ensure `minio-user` is created on all the hosts in distributed setup with write access to data folders.

--- a/linux-systemd/distributed/minio.service
+++ b/linux-systemd/distributed/minio.service
@@ -14,6 +14,10 @@ User=minio-user
 Group=minio-user
 ProtectProc=invisible
 
+# Allow binding to privileged ports (< 1024) without running as root
+# CAP_SYS_ADMIN + CAP_DAC_OVERRIDE enable S.M.A.R.T. disk health monitoring
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SYS_ADMIN CAP_DAC_OVERRIDE
+
 EnvironmentFile=-/etc/default/minio
 ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
 

--- a/linux-systemd/minio.service
+++ b/linux-systemd/minio.service
@@ -15,6 +15,10 @@ User=minio-user
 Group=minio-user
 ProtectProc=invisible
 
+# Allow binding to privileged ports (< 1024) without running as root
+# CAP_SYS_ADMIN + CAP_DAC_OVERRIDE enable S.M.A.R.T. disk health monitoring
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SYS_ADMIN CAP_DAC_OVERRIDE
+
 EnvironmentFile=/etc/default/minio
 ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
 


### PR DESCRIPTION

Add AmbientCapabilities to systemd service files:
- CAP_NET_BIND_SERVICE: bind to ports < 1024 without root
- CAP_SYS_ADMIN: NVMe admin commands for SMART data
- CAP_DAC_OVERRIDE: open block devices for SMART data

Document setcap usage for non-systemd deployments.